### PR TITLE
fix: Add duplicate slug check in createCategory to prevent E11000 error

### DIFF
--- a/controllers/categoryController.js
+++ b/controllers/categoryController.js
@@ -122,6 +122,19 @@ exports.createCategory = async (req, res) => {
       .replace(/[\s_]+/g, "-")
       .replace(/^-+|-+$/g, "");
 
+    // Check for duplicate slug
+    const existingSlug = await Category.findOne({
+      slug: slug,
+      isDeleted: false,
+    });
+
+    if (existingSlug) {
+      return res.status(400).json({
+        success: false,
+        message: `Category with slug "${slug}" already exists. Please use a different name.`,
+      });
+    }
+
     const newCategory = new Category({
       categoryId,
       name,


### PR DESCRIPTION
- Added validation to check for existing category with same slug
- Prevents MongoDB duplicate key error (E11000)
- Returns clear error message when slug already exists